### PR TITLE
Make sure e-mail validation works for new records as well

### DIFF
--- a/lib/sequel/plugins/devise.rb
+++ b/lib/sequel/plugins/devise.rb
@@ -14,7 +14,7 @@ module Sequel
         end
 
         def email_changed? # For validatable
-          column_changed? :email
+          new? || column_changed?(:email)
         end
 
         def email_was # For confirmable


### PR DESCRIPTION
sequel's dirty plugin differs from ActiveRecord::Dirty. It does not marks column changed when initializing new records:

user = User.new email: 'my@email.com'
user.column_changed?(:email) # => false
